### PR TITLE
fix: add otherIncomePaxos to CashReportCurrency attrs

### DIFF
--- a/ibflex/Types.py
+++ b/ibflex/Types.py
@@ -833,6 +833,7 @@ class CashReportCurrency(FlexElement):
     slbNetSettledCashSec: Optional[decimal.Decimal] = None
     slbNetSettledCashCom: Optional[decimal.Decimal] = None
     slbNetSettledCashPaxos: Optional[decimal.Decimal] = None
+    otherIncomePaxos: Optional[decimal.Decimal] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Parsing flex query statement with PAXOS enabled account would failed with:
`ibflex.parser.FlexParserError: CashReportCurrency has no attribute 'otherIncomePaxos'`

Adding this attribute fix this problem.

## Summary by Sourcery

Bug Fixes:
- Fix parsing error for Flex query statements with PAXOS-enabled accounts by adding the missing 'otherIncomePaxos' attribute