### PR TITLE
fix: ibkr dns resolve

### DIFF
--- a/ibflex/client.py
+++ b/ibflex/client.py
@@ -19,9 +19,9 @@ import requests
 ###############################################################################
 # SERVICE LOCATIONS
 ###############################################################################
-FLEX_URL = 'https://gdcdyn.interactivebrokers.com/Universal/servlet/'
-REQUEST_URL = FLEX_URL + 'FlexStatementService.SendRequest'
-STMT_URL = FLEX_URL + 'FlexStatementService.GetStatement'
+FLEX_URL = 'https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/'
+REQUEST_URL = FLEX_URL + 'SendRequest'
+STMT_URL = FLEX_URL + 'GetStatement'
 
 
 ###############################################################################
@@ -136,8 +136,6 @@ def request_statement(
     """First part of the 2-step download process.
     """
     url = url or REQUEST_URL
-    ### AKE FIX
-    url = 'https://ndcdyn.interactivebrokers.com/portal.flexweb/api/v1/flexQuery'
     response = submit_request(url, token, query=query_id)
     stmt_access = parse_stmt_response(response)
     if isinstance(stmt_access, StatementError):


### PR DESCRIPTION
According to https://github.com/agusalex/ghostfolio-sync/issues/29

With these modifications, the client is abled to download the statement again.

## Summary by Sourcery

Update Interactive Brokers (IBKR) API endpoint URLs to resolve DNS and statement download issues

Bug Fixes:
- Fix DNS resolution for Interactive Brokers statement download by updating service URLs

Enhancements:
- Modify IBKR Flex API endpoint configuration to use the correct service URLs